### PR TITLE
Example of child routing not working with testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function( grunt ) {
     'use strict';
 
     // Livereload and connect variables
-    var LIVERELOAD_PORT = 35729;
+    var LIVERELOAD_PORT = 35728;
     var lrSnippet = require('connect-livereload')({
         port: LIVERELOAD_PORT
     });
@@ -38,7 +38,7 @@ module.exports = function( grunt ) {
                 },
                 dev: {
                     options: {
-                        port: 8999,
+                        port: 8081,
                         hostname: 'localhost',
                         middleware: function( connect ) {
                             return [lrSnippet, mountFolder(connect, '.')];
@@ -84,7 +84,7 @@ module.exports = function( grunt ) {
             },
             jasmine: {
                 dev: {
-                    src: 'app/viewmodels/*.js',
+                    src: 'app/viewmodels/**/*.js',
                     options: {
                         specs: 'test/specs/dev/**/*spec.js',
                         keepRunner: true,

--- a/app/viewmodels/ko/index.js
+++ b/app/viewmodels/ko/index.js
@@ -1,0 +1,13 @@
+define(['plugins/router', 'knockout'], function(router, ko) {
+    var childRouter = router.createChildRouter()
+        .makeRelative({
+            moduleId:'ko',
+            fromParent:true
+        }).map([
+    { route: 'simpleList',      moduleId: 'simpleList',       title: 'Simple List',           type: 'intro',      nav: true }
+    ]).buildNavigationModel();
+
+    return {
+        router: childRouter //the property on the view model should be called router
+    };
+});

--- a/app/viewmodels/ko/simpleList.js
+++ b/app/viewmodels/ko/simpleList.js
@@ -1,0 +1,4 @@
+define([],function(){
+
+    return {};
+});

--- a/app/viewmodels/shell.js
+++ b/app/viewmodels/shell.js
@@ -9,7 +9,8 @@
         activate: function () {
             router.map([
                 { route: '', title:'Welcome', moduleId: 'viewmodels/welcome', nav: true },
-                { route: 'flickr', moduleId: 'viewmodels/flickr', nav: true }
+                { route: 'flickr', moduleId: 'viewmodels/flickr', nav: true },
+                { route: 'knockout-samples*details', moduleId: 'ko/index', title: 'Knockout Samples',  nav: true, hash: '#knockout-samples' }
             ]).buildNavigationModel();
             
             return router.activate();

--- a/lib/durandal/js/plugins/router.js
+++ b/lib/durandal/js/plugins/router.js
@@ -606,7 +606,9 @@ define(['durandal/system', 'durandal/app', 'durandal/activator', 'durandal/event
          * @return {string} The hash.
          */
         router.convertRouteToHash = function(route) {
+            console.log("ROUTE: "+route);
             if(router.relativeToParentRouter){
+                console.log("ROUTE from hash: "+route);
                 var instruction = router.parent.activeInstruction(),
                     hash = instruction.config.hash + '/' + route;
 


### PR DESCRIPTION
It doesn't look like you can do testing and have child routing. The initial active instruction is null. Is this a bug?


~/Projects/DurandalTest/HTMLStarterKitProKHos/HTMLStarterKitPro > grunt jasmine:dev
Running "jasmine:dev" (jasmine) task
Testing jasmine specs via phantom
ROUTE: simpleList
ROUTE from hash: simpleList
>> Error: define: 'null' is not an object (evaluating 'instruction.config') at
>> _SpecRunner.html:21
>> .grunt/grunt-contrib-jasmine/require.js:12 v
>> .grunt/grunt-contrib-jasmine/require.js:19
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:8
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:7 y
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:19
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:8
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:7 y
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:19
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:8
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:7 y
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:19
>> .grunt/grunt-contrib-jasmine/require.js:23
>> .grunt/grunt-contrib-jasmine/require.js:17
>> .grunt/grunt-contrib-jasmine/require.js:14 D
>> .grunt/grunt-contrib-jasmine/require.js:28
>> .grunt/grunt-contrib-jasmine/require.js:29

Warning: PhantomJS timed out, possibly due to an unfinished async spec. Use --force to continue.
